### PR TITLE
Upgrade serverless version to support python 3.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
             "name": "ldap-password-rotation-service",
             "version": "1.0.0",
             "devDependencies": {
-                "serverless": "^3.26.0",
-                "serverless-prune-plugin": "^2.0.1"
+                "serverless": "^3.37.0",
+                "serverless-prune-plugin": "^2.0.2"
             }
         },
         "cookiejar": {
@@ -17,6 +17,629 @@
             "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
             "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
             "extraneous": true
+        },
+        "node_modules/@aws-crypto/crc32": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+            "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+            "dev": true,
+            "dependencies": {
+                "@aws-crypto/util": "^3.0.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
+        },
+        "node_modules/@aws-crypto/ie11-detection": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+            "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
+        },
+        "node_modules/@aws-crypto/sha256-browser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+            "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+            "dev": true,
+            "dependencies": {
+                "@aws-crypto/ie11-detection": "^3.0.0",
+                "@aws-crypto/sha256-js": "^3.0.0",
+                "@aws-crypto/supports-web-crypto": "^3.0.0",
+                "@aws-crypto/util": "^3.0.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
+        },
+        "node_modules/@aws-crypto/sha256-js": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+            "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+            "dev": true,
+            "dependencies": {
+                "@aws-crypto/util": "^3.0.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
+        },
+        "node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+            "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
+        },
+        "node_modules/@aws-crypto/util": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+            "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+            "dev": true,
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
+        },
+        "node_modules/@aws-sdk/client-cloudformation": {
+            "version": "3.454.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.454.0.tgz",
+            "integrity": "sha512-CKOE5u2gLt/BjHYX6a0uKGsWPBic9uOzlTwqnpqXEmVSb25xv5ULHOUmYfmSyw2TWXwxEe4a6ZwBL0MYJGrEUw==",
+            "dev": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sts": "3.454.0",
+                "@aws-sdk/core": "3.451.0",
+                "@aws-sdk/credential-provider-node": "3.451.0",
+                "@aws-sdk/middleware-host-header": "3.451.0",
+                "@aws-sdk/middleware-logger": "3.451.0",
+                "@aws-sdk/middleware-recursion-detection": "3.451.0",
+                "@aws-sdk/middleware-signing": "3.451.0",
+                "@aws-sdk/middleware-user-agent": "3.451.0",
+                "@aws-sdk/region-config-resolver": "3.451.0",
+                "@aws-sdk/types": "3.451.0",
+                "@aws-sdk/util-endpoints": "3.451.0",
+                "@aws-sdk/util-user-agent-browser": "3.451.0",
+                "@aws-sdk/util-user-agent-node": "3.451.0",
+                "@smithy/config-resolver": "^2.0.18",
+                "@smithy/fetch-http-handler": "^2.2.6",
+                "@smithy/hash-node": "^2.0.15",
+                "@smithy/invalid-dependency": "^2.0.13",
+                "@smithy/middleware-content-length": "^2.0.15",
+                "@smithy/middleware-endpoint": "^2.2.0",
+                "@smithy/middleware-retry": "^2.0.20",
+                "@smithy/middleware-serde": "^2.0.13",
+                "@smithy/middleware-stack": "^2.0.7",
+                "@smithy/node-config-provider": "^2.1.5",
+                "@smithy/node-http-handler": "^2.1.9",
+                "@smithy/protocol-http": "^3.0.9",
+                "@smithy/smithy-client": "^2.1.15",
+                "@smithy/types": "^2.5.0",
+                "@smithy/url-parser": "^2.0.13",
+                "@smithy/util-base64": "^2.0.1",
+                "@smithy/util-body-length-browser": "^2.0.0",
+                "@smithy/util-body-length-node": "^2.1.0",
+                "@smithy/util-defaults-mode-browser": "^2.0.19",
+                "@smithy/util-defaults-mode-node": "^2.0.25",
+                "@smithy/util-endpoints": "^1.0.4",
+                "@smithy/util-retry": "^2.0.6",
+                "@smithy/util-utf8": "^2.0.2",
+                "@smithy/util-waiter": "^2.0.13",
+                "fast-xml-parser": "4.2.5",
+                "tslib": "^2.5.0",
+                "uuid": "^8.3.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudformation/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso": {
+            "version": "3.451.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.451.0.tgz",
+            "integrity": "sha512-KkYSke3Pdv3MfVH/5fT528+MKjMyPKlcLcd4zQb0x6/7Bl7EHrPh1JZYjzPLHelb+UY5X0qN8+cb8iSu1eiwIQ==",
+            "dev": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/core": "3.451.0",
+                "@aws-sdk/middleware-host-header": "3.451.0",
+                "@aws-sdk/middleware-logger": "3.451.0",
+                "@aws-sdk/middleware-recursion-detection": "3.451.0",
+                "@aws-sdk/middleware-user-agent": "3.451.0",
+                "@aws-sdk/region-config-resolver": "3.451.0",
+                "@aws-sdk/types": "3.451.0",
+                "@aws-sdk/util-endpoints": "3.451.0",
+                "@aws-sdk/util-user-agent-browser": "3.451.0",
+                "@aws-sdk/util-user-agent-node": "3.451.0",
+                "@smithy/config-resolver": "^2.0.18",
+                "@smithy/fetch-http-handler": "^2.2.6",
+                "@smithy/hash-node": "^2.0.15",
+                "@smithy/invalid-dependency": "^2.0.13",
+                "@smithy/middleware-content-length": "^2.0.15",
+                "@smithy/middleware-endpoint": "^2.2.0",
+                "@smithy/middleware-retry": "^2.0.20",
+                "@smithy/middleware-serde": "^2.0.13",
+                "@smithy/middleware-stack": "^2.0.7",
+                "@smithy/node-config-provider": "^2.1.5",
+                "@smithy/node-http-handler": "^2.1.9",
+                "@smithy/protocol-http": "^3.0.9",
+                "@smithy/smithy-client": "^2.1.15",
+                "@smithy/types": "^2.5.0",
+                "@smithy/url-parser": "^2.0.13",
+                "@smithy/util-base64": "^2.0.1",
+                "@smithy/util-body-length-browser": "^2.0.0",
+                "@smithy/util-body-length-node": "^2.1.0",
+                "@smithy/util-defaults-mode-browser": "^2.0.19",
+                "@smithy/util-defaults-mode-node": "^2.0.25",
+                "@smithy/util-endpoints": "^1.0.4",
+                "@smithy/util-retry": "^2.0.6",
+                "@smithy/util-utf8": "^2.0.2",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts": {
+            "version": "3.454.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.454.0.tgz",
+            "integrity": "sha512-0fDvr8WeB6IYO8BUCzcivWmahgGl/zDbaYfakzGnt4mrl5ztYaXE875WI6b7+oFcKMRvN+KLvwu5TtyFuNY+GQ==",
+            "dev": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/core": "3.451.0",
+                "@aws-sdk/credential-provider-node": "3.451.0",
+                "@aws-sdk/middleware-host-header": "3.451.0",
+                "@aws-sdk/middleware-logger": "3.451.0",
+                "@aws-sdk/middleware-recursion-detection": "3.451.0",
+                "@aws-sdk/middleware-sdk-sts": "3.451.0",
+                "@aws-sdk/middleware-signing": "3.451.0",
+                "@aws-sdk/middleware-user-agent": "3.451.0",
+                "@aws-sdk/region-config-resolver": "3.451.0",
+                "@aws-sdk/types": "3.451.0",
+                "@aws-sdk/util-endpoints": "3.451.0",
+                "@aws-sdk/util-user-agent-browser": "3.451.0",
+                "@aws-sdk/util-user-agent-node": "3.451.0",
+                "@smithy/config-resolver": "^2.0.18",
+                "@smithy/fetch-http-handler": "^2.2.6",
+                "@smithy/hash-node": "^2.0.15",
+                "@smithy/invalid-dependency": "^2.0.13",
+                "@smithy/middleware-content-length": "^2.0.15",
+                "@smithy/middleware-endpoint": "^2.2.0",
+                "@smithy/middleware-retry": "^2.0.20",
+                "@smithy/middleware-serde": "^2.0.13",
+                "@smithy/middleware-stack": "^2.0.7",
+                "@smithy/node-config-provider": "^2.1.5",
+                "@smithy/node-http-handler": "^2.1.9",
+                "@smithy/protocol-http": "^3.0.9",
+                "@smithy/smithy-client": "^2.1.15",
+                "@smithy/types": "^2.5.0",
+                "@smithy/url-parser": "^2.0.13",
+                "@smithy/util-base64": "^2.0.1",
+                "@smithy/util-body-length-browser": "^2.0.0",
+                "@smithy/util-body-length-node": "^2.1.0",
+                "@smithy/util-defaults-mode-browser": "^2.0.19",
+                "@smithy/util-defaults-mode-node": "^2.0.25",
+                "@smithy/util-endpoints": "^1.0.4",
+                "@smithy/util-retry": "^2.0.6",
+                "@smithy/util-utf8": "^2.0.2",
+                "fast-xml-parser": "4.2.5",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/core": {
+            "version": "3.451.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.451.0.tgz",
+            "integrity": "sha512-SamWW2zHEf1ZKe3j1w0Piauryl8BQIlej0TBS18A4ACzhjhWXhCs13bO1S88LvPR5mBFXok3XOT6zPOnKDFktw==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/smithy-client": "^2.1.15",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.451.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.451.0.tgz",
+            "integrity": "sha512-9dAav7DcRgaF7xCJEQR5ER9ErXxnu/tdnVJ+UPmb1NPeIZdESv1A3lxFDEq1Fs8c4/lzAj9BpshGyJVIZwZDKg==",
+            "dev": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.451.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/types": "^2.5.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.451.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.451.0.tgz",
+            "integrity": "sha512-TySt64Ci5/ZbqFw1F9Z0FIGvYx5JSC9e6gqDnizIYd8eMnn8wFRUscRrD7pIHKfrhvVKN5h0GdYovmMO/FMCBw==",
+            "dev": true,
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.451.0",
+                "@aws-sdk/credential-provider-process": "3.451.0",
+                "@aws-sdk/credential-provider-sso": "3.451.0",
+                "@aws-sdk/credential-provider-web-identity": "3.451.0",
+                "@aws-sdk/types": "3.451.0",
+                "@smithy/credential-provider-imds": "^2.0.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/shared-ini-file-loader": "^2.0.6",
+                "@smithy/types": "^2.5.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.451.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.451.0.tgz",
+            "integrity": "sha512-AEwM1WPyxUdKrKyUsKyFqqRFGU70e4qlDyrtBxJnSU9NRLZI8tfEZ67bN7fHSxBUBODgDXpMSlSvJiBLh5/3pw==",
+            "dev": true,
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.451.0",
+                "@aws-sdk/credential-provider-ini": "3.451.0",
+                "@aws-sdk/credential-provider-process": "3.451.0",
+                "@aws-sdk/credential-provider-sso": "3.451.0",
+                "@aws-sdk/credential-provider-web-identity": "3.451.0",
+                "@aws-sdk/types": "3.451.0",
+                "@smithy/credential-provider-imds": "^2.0.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/shared-ini-file-loader": "^2.0.6",
+                "@smithy/types": "^2.5.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.451.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.451.0.tgz",
+            "integrity": "sha512-HQywSdKeD5PErcLLnZfSyCJO+6T+ZyzF+Lm/QgscSC+CbSUSIPi//s15qhBRVely/3KBV6AywxwNH+5eYgt4lQ==",
+            "dev": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.451.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/shared-ini-file-loader": "^2.0.6",
+                "@smithy/types": "^2.5.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.451.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.451.0.tgz",
+            "integrity": "sha512-Usm/N51+unOt8ID4HnQzxIjUJDrkAQ1vyTOC0gSEEJ7h64NSSPGD5yhN7il5WcErtRd3EEtT1a8/GTC5TdBctg==",
+            "dev": true,
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.451.0",
+                "@aws-sdk/token-providers": "3.451.0",
+                "@aws-sdk/types": "3.451.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/shared-ini-file-loader": "^2.0.6",
+                "@smithy/types": "^2.5.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.451.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.451.0.tgz",
+            "integrity": "sha512-Xtg3Qw65EfDjWNG7o2xD6sEmumPfsy3WDGjk2phEzVg8s7hcZGxf5wYwe6UY7RJvlEKrU0rFA+AMn6Hfj5oOzg==",
+            "dev": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.451.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/types": "^2.5.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.451.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.451.0.tgz",
+            "integrity": "sha512-j8a5jAfhWmsK99i2k8oR8zzQgXrsJtgrLxc3js6U+525mcZytoiDndkWTmD5fjJ1byU1U2E5TaPq+QJeDip05Q==",
+            "dev": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.451.0",
+                "@smithy/protocol-http": "^3.0.9",
+                "@smithy/types": "^2.5.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.451.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.451.0.tgz",
+            "integrity": "sha512-0kHrYEyVeB2QBfP6TfbI240aRtatLZtcErJbhpiNUb+CQPgEL3crIjgVE8yYiJumZ7f0jyjo8HLPkwD1/2APaw==",
+            "dev": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.451.0",
+                "@smithy/types": "^2.5.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.451.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.451.0.tgz",
+            "integrity": "sha512-J6jL6gJ7orjHGM70KDRcCP7so/J2SnkN4vZ9YRLTeeZY6zvBuHDjX8GCIgSqPn/nXFXckZO8XSnA7u6+3TAT0w==",
+            "dev": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.451.0",
+                "@smithy/protocol-http": "^3.0.9",
+                "@smithy/types": "^2.5.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-sts": {
+            "version": "3.451.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.451.0.tgz",
+            "integrity": "sha512-UJ6UfVUEgp0KIztxpAeelPXI5MLj9wUtUCqYeIMP7C1ZhoEMNm3G39VLkGN43dNhBf1LqjsV9jkKMZbVfYXuwg==",
+            "dev": true,
+            "dependencies": {
+                "@aws-sdk/middleware-signing": "3.451.0",
+                "@aws-sdk/types": "3.451.0",
+                "@smithy/types": "^2.5.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-signing": {
+            "version": "3.451.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.451.0.tgz",
+            "integrity": "sha512-s5ZlcIoLNg1Huj4Qp06iKniE8nJt/Pj1B/fjhWc6cCPCM7XJYUCejCnRh6C5ZJoBEYodjuwZBejPc1Wh3j+znA==",
+            "dev": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.451.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/protocol-http": "^3.0.9",
+                "@smithy/signature-v4": "^2.0.0",
+                "@smithy/types": "^2.5.0",
+                "@smithy/util-middleware": "^2.0.6",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.451.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.451.0.tgz",
+            "integrity": "sha512-8NM/0JiKLNvT9wtAQVl1DFW0cEO7OvZyLSUBLNLTHqyvOZxKaZ8YFk7d8PL6l76LeUKRxq4NMxfZQlUIRe0eSA==",
+            "dev": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.451.0",
+                "@aws-sdk/util-endpoints": "3.451.0",
+                "@smithy/protocol-http": "^3.0.9",
+                "@smithy/types": "^2.5.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.451.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.451.0.tgz",
+            "integrity": "sha512-3iMf4OwzrFb4tAAmoROXaiORUk2FvSejnHIw/XHvf/jjR4EqGGF95NZP/n/MeFZMizJWVssrwS412GmoEyoqhg==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^2.1.5",
+                "@smithy/types": "^2.5.0",
+                "@smithy/util-config-provider": "^2.0.0",
+                "@smithy/util-middleware": "^2.0.6",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers": {
+            "version": "3.451.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.451.0.tgz",
+            "integrity": "sha512-ij1L5iUbn6CwxVOT1PG4NFjsrsKN9c4N1YEM0lkl6DwmaNOscjLKGSNyj9M118vSWsOs1ZDbTwtj++h0O/BWrQ==",
+            "dev": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/middleware-host-header": "3.451.0",
+                "@aws-sdk/middleware-logger": "3.451.0",
+                "@aws-sdk/middleware-recursion-detection": "3.451.0",
+                "@aws-sdk/middleware-user-agent": "3.451.0",
+                "@aws-sdk/region-config-resolver": "3.451.0",
+                "@aws-sdk/types": "3.451.0",
+                "@aws-sdk/util-endpoints": "3.451.0",
+                "@aws-sdk/util-user-agent-browser": "3.451.0",
+                "@aws-sdk/util-user-agent-node": "3.451.0",
+                "@smithy/config-resolver": "^2.0.18",
+                "@smithy/fetch-http-handler": "^2.2.6",
+                "@smithy/hash-node": "^2.0.15",
+                "@smithy/invalid-dependency": "^2.0.13",
+                "@smithy/middleware-content-length": "^2.0.15",
+                "@smithy/middleware-endpoint": "^2.2.0",
+                "@smithy/middleware-retry": "^2.0.20",
+                "@smithy/middleware-serde": "^2.0.13",
+                "@smithy/middleware-stack": "^2.0.7",
+                "@smithy/node-config-provider": "^2.1.5",
+                "@smithy/node-http-handler": "^2.1.9",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/protocol-http": "^3.0.9",
+                "@smithy/shared-ini-file-loader": "^2.0.6",
+                "@smithy/smithy-client": "^2.1.15",
+                "@smithy/types": "^2.5.0",
+                "@smithy/url-parser": "^2.0.13",
+                "@smithy/util-base64": "^2.0.1",
+                "@smithy/util-body-length-browser": "^2.0.0",
+                "@smithy/util-body-length-node": "^2.1.0",
+                "@smithy/util-defaults-mode-browser": "^2.0.19",
+                "@smithy/util-defaults-mode-node": "^2.0.25",
+                "@smithy/util-endpoints": "^1.0.4",
+                "@smithy/util-retry": "^2.0.6",
+                "@smithy/util-utf8": "^2.0.2",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/types": {
+            "version": "3.451.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
+            "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/types": "^2.5.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.451.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.451.0.tgz",
+            "integrity": "sha512-giqLGBTnRIcKkDqwU7+GQhKbtJ5Ku35cjGQIfMyOga6pwTBUbaK0xW1Sdd8sBQ1GhApscnChzI9o/R9x0368vw==",
+            "dev": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.451.0",
+                "@smithy/util-endpoints": "^1.0.4",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-locate-window": {
+            "version": "3.310.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
+            "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.451.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.451.0.tgz",
+            "integrity": "sha512-Ws5mG3J0TQifH7OTcMrCTexo7HeSAc3cBgjfhS/ofzPUzVCtsyg0G7I6T7wl7vJJETix2Kst2cpOsxygPgPD9w==",
+            "dev": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.451.0",
+                "@smithy/types": "^2.5.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.451.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.451.0.tgz",
+            "integrity": "sha512-TBzm6P+ql4mkGFAjPlO1CI+w3yUT+NulaiALjl/jNX/nnUp6HsJsVxJf4nVFQTG5KRV0iqMypcs7I3KIhH+LmA==",
+            "dev": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.451.0",
+                "@smithy/node-config-provider": "^2.1.5",
+                "@smithy/types": "^2.5.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/util-utf8-browser": {
+            "version": "3.259.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+            "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.3.1"
+            }
         },
         "node_modules/@kwsites/file-exists": {
             "version": "1.1.1",
@@ -69,34 +692,67 @@
             }
         },
         "node_modules/@serverless/dashboard-plugin": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/@serverless/dashboard-plugin/-/dashboard-plugin-6.2.2.tgz",
-            "integrity": "sha512-h3zOprpuWZCdAP7qoOKT2nboB+AaxMkGoSzOD0jIBpt9s0cXqLE2VFjR2vKn8Cvam47Qa3XYnT2/XN6tR6rZgQ==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@serverless/dashboard-plugin/-/dashboard-plugin-7.2.0.tgz",
+            "integrity": "sha512-Gqzgef+KmrX1OxJW9aubrIN6AvPrtDARMv+NegMNEe+pfkZA/IMuZiSyYUaHgARokdw2/IALOysTLgdFJIrXvA==",
             "dev": true,
             "dependencies": {
+                "@aws-sdk/client-cloudformation": "^3.410.0",
+                "@aws-sdk/client-sts": "^3.410.0",
                 "@serverless/event-mocks": "^1.1.1",
-                "@serverless/platform-client": "^4.3.2",
-                "@serverless/utils": "^6.0.3",
-                "child-process-ext": "^2.1.1",
+                "@serverless/platform-client": "^4.5.1",
+                "@serverless/utils": "^6.14.0",
+                "child-process-ext": "^3.0.1",
                 "chokidar": "^3.5.3",
                 "flat": "^5.0.2",
                 "fs-extra": "^9.1.0",
                 "js-yaml": "^4.1.0",
-                "jszip": "^3.9.1",
+                "jszip": "^3.10.1",
                 "lodash": "^4.17.21",
                 "memoizee": "^0.4.15",
-                "ncjsm": "^4.3.0",
+                "ncjsm": "^4.3.2",
                 "node-dir": "^0.1.17",
-                "node-fetch": "^2.6.7",
+                "node-fetch": "^2.6.8",
                 "open": "^7.4.2",
-                "semver": "^7.3.7",
-                "simple-git": "^3.7.0",
-                "type": "^2.6.0",
+                "semver": "^7.3.8",
+                "simple-git": "^3.16.0",
+                "timers-ext": "^0.1.7",
+                "type": "^2.7.2",
                 "uuid": "^8.3.2",
                 "yamljs": "^0.3.0"
             },
             "engines": {
                 "node": ">=12.0"
+            }
+        },
+        "node_modules/@serverless/dashboard-plugin/node_modules/child-process-ext": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/child-process-ext/-/child-process-ext-3.0.2.tgz",
+            "integrity": "sha512-oBePsLbQpTJFxzwyCvs9yWWF0OEM6vGGepHwt1stqmX7QQqOuDc8j2ywdvAs9Tvi44TT7d9ackqhR4Q10l1u8w==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "es5-ext": "^0.10.62",
+                "log": "^6.3.1",
+                "split2": "^3.2.2",
+                "stream-promise": "^3.2.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/@serverless/dashboard-plugin/node_modules/cross-spawn": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "dev": true,
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/@serverless/dashboard-plugin/node_modules/fs-extra": {
@@ -130,6 +786,36 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/@serverless/dashboard-plugin/node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@serverless/dashboard-plugin/node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@serverless/dashboard-plugin/node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/@serverless/dashboard-plugin/node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -137,6 +823,21 @@
             "dev": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@serverless/dashboard-plugin/node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/@serverless/event-mocks": {
@@ -198,14 +899,14 @@
             }
         },
         "node_modules/@serverless/utils": {
-            "version": "6.8.2",
-            "resolved": "https://registry.npmjs.org/@serverless/utils/-/utils-6.8.2.tgz",
-            "integrity": "sha512-FW8zdG8OPoF6qgyutiMhz4m/5SxbQjoQdbaGcW3wU6xe3QzQh41Hif7I3Xuu4J62CvxiWuz19sxNDJz2mTcskw==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@serverless/utils/-/utils-6.15.0.tgz",
+            "integrity": "sha512-7eDbqKv/OBd11jjdZjUwFGN8sHWkeUqLeHXHQxQ1azja2IM7WIH+z/aLgzR6LhB3/MINNwtjesDpjGqTMj2JKQ==",
             "dev": true,
             "dependencies": {
                 "archive-type": "^4.0.0",
                 "chalk": "^4.1.2",
-                "ci-info": "^3.5.0",
+                "ci-info": "^3.8.0",
                 "cli-progress-footer": "^2.3.2",
                 "content-disposition": "^0.5.4",
                 "d": "^1.0.1",
@@ -216,18 +917,19 @@
                 "file-type": "^16.5.4",
                 "filenamify": "^4.3.0",
                 "get-stream": "^6.0.1",
-                "got": "^11.8.5",
+                "got": "^11.8.6",
                 "inquirer": "^8.2.5",
                 "js-yaml": "^4.1.0",
                 "jwt-decode": "^3.1.2",
                 "lodash": "^4.17.21",
                 "log": "^6.3.1",
                 "log-node": "^8.0.3",
-                "make-dir": "^3.1.0",
+                "make-dir": "^4.0.0",
                 "memoizee": "^0.4.15",
-                "ncjsm": "^4.3.1",
-                "node-fetch": "^2.6.7",
-                "open": "^8.4.0",
+                "ms": "^2.1.3",
+                "ncjsm": "^4.3.2",
+                "node-fetch": "^2.6.11",
+                "open": "^8.4.2",
                 "p-event": "^4.2.0",
                 "supports-color": "^8.1.1",
                 "timers-ext": "^0.1.7",
@@ -244,6 +946,12 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
             "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==",
+            "dev": true
+        },
+        "node_modules/@serverless/utils/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true
         },
         "node_modules/@serverless/utils/node_modules/uuid": {
@@ -265,6 +973,569 @@
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/is?sponsor=1"
+            }
+        },
+        "node_modules/@smithy/abort-controller": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.14.tgz",
+            "integrity": "sha512-zXtteuYLWbSXnzI3O6xq3FYvigYZFW8mdytGibfarLL2lxHto9L3ILtGVnVGmFZa7SDh62l39EnU5hesLN87Fw==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/types": "^2.6.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/config-resolver": {
+            "version": "2.0.19",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.19.tgz",
+            "integrity": "sha512-JsghnQ5zjWmjEVY8TFOulLdEOCj09SjRLugrHlkPZTIBBm7PQitCFVLThbsKPZQOP7N3ME1DU1nKUc1UaVnBog==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^2.1.6",
+                "@smithy/types": "^2.6.0",
+                "@smithy/util-config-provider": "^2.0.0",
+                "@smithy/util-middleware": "^2.0.7",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/credential-provider-imds": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.1.2.tgz",
+            "integrity": "sha512-Y62jBWdoLPSYjr9fFvJf+KwTa1EunjVr6NryTEWCnwIY93OJxwV4t0qxjwdPl/XMsUkq79ppNJSEQN6Ohnhxjw==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^2.1.6",
+                "@smithy/property-provider": "^2.0.15",
+                "@smithy/types": "^2.6.0",
+                "@smithy/url-parser": "^2.0.14",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/eventstream-codec": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.14.tgz",
+            "integrity": "sha512-g/OU/MeWGfHDygoXgMWfG/Xb0QqDnAGcM9t2FRrVAhleXYRddGOEnfanR5cmHgB9ue52MJsyorqFjckzXsylaA==",
+            "dev": true,
+            "dependencies": {
+                "@aws-crypto/crc32": "3.0.0",
+                "@smithy/types": "^2.6.0",
+                "@smithy/util-hex-encoding": "^2.0.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@smithy/fetch-http-handler": {
+            "version": "2.2.7",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.7.tgz",
+            "integrity": "sha512-iSDBjxuH9TgrtMYAr7j5evjvkvgwLY3y+9D547uep+JNkZ1ZT+BaeU20j6I/bO/i26ilCWFImrlXTPsfQtZdIQ==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^3.0.10",
+                "@smithy/querystring-builder": "^2.0.14",
+                "@smithy/types": "^2.6.0",
+                "@smithy/util-base64": "^2.0.1",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@smithy/hash-node": {
+            "version": "2.0.16",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.16.tgz",
+            "integrity": "sha512-Wbi9A0PacMYUOwjAulQP90Wl3mQ6NDwnyrZQzFjDz+UzjXOSyQMgBrTkUBz+pVoYVlX3DUu24gWMZBcit+wOGg==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/types": "^2.6.0",
+                "@smithy/util-buffer-from": "^2.0.0",
+                "@smithy/util-utf8": "^2.0.2",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/invalid-dependency": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.14.tgz",
+            "integrity": "sha512-d8ohpwZo9RzTpGlAfsWtfm1SHBSU7+N4iuZ6MzR10xDTujJJWtmXYHK1uzcr7rggbpUTaWyHpPFgnf91q0EFqQ==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/types": "^2.6.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@smithy/is-array-buffer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
+            "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-content-length": {
+            "version": "2.0.16",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.16.tgz",
+            "integrity": "sha512-9ddDia3pp1d3XzLXKcm7QebGxLq9iwKf+J1LapvlSOhpF8EM9SjMeSrMOOFgG+2TfW5K3+qz4IAJYYm7INYCng==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^3.0.10",
+                "@smithy/types": "^2.6.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-endpoint": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.2.1.tgz",
+            "integrity": "sha512-dVDS7HNJl/wb0lpByXor6whqDbb1YlLoaoWYoelyYzLHioXOE7y/0iDwJWtDcN36/tVCw9EPBFZ3aans84jLpg==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/middleware-serde": "^2.0.14",
+                "@smithy/node-config-provider": "^2.1.6",
+                "@smithy/shared-ini-file-loader": "^2.2.5",
+                "@smithy/types": "^2.6.0",
+                "@smithy/url-parser": "^2.0.14",
+                "@smithy/util-middleware": "^2.0.7",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-retry": {
+            "version": "2.0.21",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.21.tgz",
+            "integrity": "sha512-EZS1EXv1k6IJX6hyu/0yNQuPcPaXwG8SWljQHYueyRbOxmqYgoWMWPtfZj0xRRQ4YtLawQSpBgAeiJltq8/MPw==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^2.1.6",
+                "@smithy/protocol-http": "^3.0.10",
+                "@smithy/service-error-classification": "^2.0.7",
+                "@smithy/types": "^2.6.0",
+                "@smithy/util-middleware": "^2.0.7",
+                "@smithy/util-retry": "^2.0.7",
+                "tslib": "^2.5.0",
+                "uuid": "^8.3.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@smithy/middleware-serde": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.14.tgz",
+            "integrity": "sha512-hFi3FqoYWDntCYA2IGY6gJ6FKjq2gye+1tfxF2HnIJB5uW8y2DhpRNBSUMoqP+qvYzRqZ6ntv4kgbG+o3pX57g==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/types": "^2.6.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-stack": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.8.tgz",
+            "integrity": "sha512-7/N59j0zWqVEKExJcA14MrLDZ/IeN+d6nbkN8ucs+eURyaDUXWYlZrQmMOd/TyptcQv0+RDlgag/zSTTV62y/Q==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/types": "^2.6.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/node-config-provider": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.6.tgz",
+            "integrity": "sha512-HLqTs6O78m3M3z1cPLFxddxhEPv5MkVatfPuxoVO3A+cHZanNd/H5I6btcdHy6N2CB1MJ/lihJC92h30SESsBA==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/property-provider": "^2.0.15",
+                "@smithy/shared-ini-file-loader": "^2.2.5",
+                "@smithy/types": "^2.6.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/node-http-handler": {
+            "version": "2.1.10",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.10.tgz",
+            "integrity": "sha512-lkALAwtN6odygIM4nB8aHDahINM6WXXjNrZmWQAh0RSossySRT2qa31cFv0ZBuAYVWeprskRk13AFvvLmf1WLw==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/abort-controller": "^2.0.14",
+                "@smithy/protocol-http": "^3.0.10",
+                "@smithy/querystring-builder": "^2.0.14",
+                "@smithy/types": "^2.6.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/property-provider": {
+            "version": "2.0.15",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.15.tgz",
+            "integrity": "sha512-YbRFBn8oiiC3o1Kn3a4KjGa6k47rCM9++5W9cWqYn9WnkyH+hBWgfJAckuxpyA2Hq6Ys4eFrWzXq6fqHEw7iew==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/types": "^2.6.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/protocol-http": {
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.10.tgz",
+            "integrity": "sha512-6+tjNk7rXW7YTeGo9qwxXj/2BFpJTe37kTj3EnZCoX/nH+NP/WLA7O83fz8XhkGqsaAhLUPo/bB12vvd47nsmg==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/types": "^2.6.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-builder": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.14.tgz",
+            "integrity": "sha512-lQ4pm9vTv9nIhl5jt6uVMPludr6syE2FyJmHsIJJuOD7QPIJnrf9HhUGf1iHh9KJ4CUv21tpOU3X6s0rB6uJ0g==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/types": "^2.6.0",
+                "@smithy/util-uri-escape": "^2.0.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-parser": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.14.tgz",
+            "integrity": "sha512-+cbtXWI9tNtQjlgQg3CA+pvL3zKTAxPnG3Pj6MP89CR3vi3QMmD0SOWoq84tqZDnJCxlsusbgIXk1ngMReXo+A==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/types": "^2.6.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/service-error-classification": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.7.tgz",
+            "integrity": "sha512-LLxgW12qGz8doYto15kZ4x1rHjtXl0BnCG6T6Wb8z2DI4PT9cJfOSvzbuLzy7+5I24PAepKgFeWHRd9GYy3Z9w==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/types": "^2.6.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/shared-ini-file-loader": {
+            "version": "2.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.5.tgz",
+            "integrity": "sha512-LHA68Iu7SmNwfAVe8egmjDCy648/7iJR/fK1UnVw+iAOUJoEYhX2DLgVd5pWllqdDiRbQQzgaHLcRokM+UFR1w==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/types": "^2.6.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/signature-v4": {
+            "version": "2.0.16",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.16.tgz",
+            "integrity": "sha512-ilLY85xS2kZZzTb83diQKYLIYALvart0KnBaKnIRnMBHAGEio5aHSlANQoxVn0VsonwmQ3CnWhnCT0sERD8uTg==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/eventstream-codec": "^2.0.14",
+                "@smithy/is-array-buffer": "^2.0.0",
+                "@smithy/types": "^2.6.0",
+                "@smithy/util-hex-encoding": "^2.0.0",
+                "@smithy/util-middleware": "^2.0.7",
+                "@smithy/util-uri-escape": "^2.0.0",
+                "@smithy/util-utf8": "^2.0.2",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/smithy-client": {
+            "version": "2.1.16",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.16.tgz",
+            "integrity": "sha512-Lw67+yQSpLl4YkDLUzI2KgS8TXclXmbzSeOJUmRFS4ueT56B4pw3RZRF/SRzvgyxM/HxgkUan8oSHXCujPDafQ==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/middleware-stack": "^2.0.8",
+                "@smithy/types": "^2.6.0",
+                "@smithy/util-stream": "^2.0.21",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/types": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.6.0.tgz",
+            "integrity": "sha512-PgqxJq2IcdMF9iAasxcqZqqoOXBHufEfmbEUdN1pmJrJltT42b0Sc8UiYSWWzKkciIp9/mZDpzYi4qYG1qqg6g==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/url-parser": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.14.tgz",
+            "integrity": "sha512-kbu17Y1AFXi5lNlySdDj7ZzmvupyWKCX/0jNZ8ffquRyGdbDZb+eBh0QnWqsSmnZa/ctyWaTf7n4l/pXLExrnw==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/querystring-parser": "^2.0.14",
+                "@smithy/types": "^2.6.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@smithy/util-base64": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.1.tgz",
+            "integrity": "sha512-DlI6XFYDMsIVN+GH9JtcRp3j02JEVuWIn/QOZisVzpIAprdsxGveFed0bjbMRCqmIFe8uetn5rxzNrBtIGrPIQ==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.0.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-body-length-browser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
+            "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@smithy/util-body-length-node": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
+            "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-buffer-from": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
+            "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.0.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-config-provider": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
+            "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "2.0.20",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.20.tgz",
+            "integrity": "sha512-QJtnbTIl0/BbEASkx1MUFf6EaoWqWW1/IM90N++8NNscePvPf77GheYfpoPis6CBQawUWq8QepTP2QUSAdrVkw==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/property-provider": "^2.0.15",
+                "@smithy/smithy-client": "^2.1.16",
+                "@smithy/types": "^2.6.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-node": {
+            "version": "2.0.26",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.26.tgz",
+            "integrity": "sha512-lGFPOFCHv1ql019oegYqa54BZH7HREw6EBqjDLbAr0wquMX0BDi2sg8TJ6Eq+JGLijkZbJB73m4+aK8OFAapMg==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/config-resolver": "^2.0.19",
+                "@smithy/credential-provider-imds": "^2.1.2",
+                "@smithy/node-config-provider": "^2.1.6",
+                "@smithy/property-provider": "^2.0.15",
+                "@smithy/smithy-client": "^2.1.16",
+                "@smithy/types": "^2.6.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@smithy/util-endpoints": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.5.tgz",
+            "integrity": "sha512-K7qNuCOD5K/90MjHvHm9kJldrfm40UxWYQxNEShMFxV/lCCCRIg8R4uu1PFAxRvPxNpIdcrh1uK6I1ISjDXZJw==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^2.1.6",
+                "@smithy/types": "^2.6.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-hex-encoding": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
+            "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-middleware": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.7.tgz",
+            "integrity": "sha512-tRINOTlf1G9B0ECarFQAtTgMhpnrMPSa+5j4ZEwEawCLfTFTavk6757sxhE4RY5RMlD/I3x+DCS8ZUiR8ho9Pw==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/types": "^2.6.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-retry": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.7.tgz",
+            "integrity": "sha512-fIe5yARaF0+xVT1XKcrdnHKTJ1Vc4+3e3tLDjCuIcE9b6fkBzzGFY7AFiX4M+vj6yM98DrwkuZeHf7/hmtVp0Q==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/service-error-classification": "^2.0.7",
+                "@smithy/types": "^2.6.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-stream": {
+            "version": "2.0.21",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.21.tgz",
+            "integrity": "sha512-0BUE16d7n1x7pi1YluXJdB33jOTyBChT0j/BlOkFa9uxfg6YqXieHxjHNuCdJRARa7AZEj32LLLEPJ1fSa4inA==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^2.2.7",
+                "@smithy/node-http-handler": "^2.1.10",
+                "@smithy/types": "^2.6.0",
+                "@smithy/util-base64": "^2.0.1",
+                "@smithy/util-buffer-from": "^2.0.0",
+                "@smithy/util-hex-encoding": "^2.0.0",
+                "@smithy/util-utf8": "^2.0.2",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-uri-escape": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
+            "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-utf8": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.2.tgz",
+            "integrity": "sha512-qOiVORSPm6Ce4/Yu6hbSgNHABLP2VMv8QOC3tTDNHHlWY19pPyc++fBTbZPtx6egPXi4HQxKDnMxVxpbtX2GoA==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.0.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-waiter": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.14.tgz",
+            "integrity": "sha512-Q6gSz4GUNjNGhrfNg+2Mjy+7K4pEI3r82x1b/+3dSc03MQqobMiUrRVN/YK/4nHVagvBELCoXsiHAFQJNQ5BeA==",
+            "dev": true,
+            "dependencies": {
+                "@smithy/abort-controller": "^2.0.14",
+                "@smithy/types": "^2.6.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@szmarczak/http-timer": {
@@ -298,9 +1569,9 @@
             }
         },
         "node_modules/@types/http-cache-semantics": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-            "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+            "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
             "dev": true
         },
         "node_modules/@types/keyv": {
@@ -313,21 +1584,24 @@
             }
         },
         "node_modules/@types/lodash": {
-            "version": "4.14.191",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
-            "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+            "version": "4.14.202",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+            "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "18.11.18",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-            "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
-            "dev": true
+            "version": "20.9.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.4.tgz",
+            "integrity": "sha512-wmyg8HUhcn6ACjsn8oKYjkN/zUzQeNtMy44weTJSM6p4MMzEOuKbA3OjJ267uPCOW7Xex9dyrNTful8XTQYoDA==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/@types/responselike": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-            "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+            "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
@@ -341,6 +1615,18 @@
             "dependencies": {
                 "d": "1",
                 "es5-ext": "^0.10.47"
+            }
+        },
+        "node_modules/abort-controller": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+            "dev": true,
+            "dependencies": {
+                "event-target-shim": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=6.5"
             }
         },
         "node_modules/adm-zip": {
@@ -365,9 +1651,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "8.11.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
-            "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
+            "version": "8.12.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
             "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -471,16 +1757,16 @@
             }
         },
         "node_modules/archiver": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.1.tgz",
-            "integrity": "sha512-8KyabkmbYrH+9ibcTScQ1xCJC/CGcugdVIwB+53f5sZziXgwUh3iXlAlANMxcZyDEfTHMe6+Z5FofV8nopXP7w==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+            "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
             "dev": true,
             "dependencies": {
                 "archiver-utils": "^2.1.0",
-                "async": "^3.2.3",
+                "async": "^3.2.4",
                 "buffer-crc32": "^0.2.1",
                 "readable-stream": "^3.6.0",
-                "readdir-glob": "^1.0.0",
+                "readdir-glob": "^1.1.2",
                 "tar-stream": "^2.2.0",
                 "zip-stream": "^4.1.0"
             },
@@ -510,9 +1796,9 @@
             }
         },
         "node_modules/archiver-utils/node_modules/readable-stream": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "dev": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
@@ -561,9 +1847,9 @@
             "dev": true
         },
         "node_modules/async": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-            "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+            "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
             "dev": true
         },
         "node_modules/asynckit": {
@@ -594,9 +1880,9 @@
             }
         },
         "node_modules/aws-sdk": {
-            "version": "2.1354.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1354.0.tgz",
-            "integrity": "sha512-3aDxvyuOqMB9DqJguCq6p8momdsz0JR1axwkWOOCzHA7a35+Bw+WLmqt3pWwRjR1tGIwkkZ2CvGJObYHsOuw3w==",
+            "version": "2.1501.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1501.0.tgz",
+            "integrity": "sha512-mlYhHlB255oov0ks06hxEUYzOHji4urr0xJ8TRbkgUnp1lYdNaTjUFpwzfqbA7w74ZD6gJtca/EjDxk8g4SSSQ==",
             "dev": true,
             "dependencies": {
                 "buffer": "4.9.2",
@@ -720,6 +2006,12 @@
             "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
             "dev": true
         },
+        "node_modules/bowser": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+            "dev": true
+        },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -812,9 +2104,9 @@
             }
         },
         "node_modules/cacheable-request": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
-            "integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+            "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
             "dev": true,
             "dependencies": {
                 "clone-response": "^1.0.2",
@@ -854,13 +2146,14 @@
             }
         },
         "node_modules/call-bind": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+            "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
             "dev": true,
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.2"
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.1",
+                "set-function-length": "^1.1.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -950,9 +2243,9 @@
             }
         },
         "node_modules/ci-info": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
-            "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==",
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
             "dev": true,
             "funding": [
                 {
@@ -1011,9 +2304,9 @@
             }
         },
         "node_modules/cli-spinners": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
-            "integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==",
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.1.tgz",
+            "integrity": "sha512-jHgecW0pxkonBJdrKsqxgRX9AcG+u/5k0Q7WPDfi8AogLAdwxEkyYYNWwZ5GvVFoFx2uiY1eNcSK00fh+1+FyQ==",
             "dev": true,
             "engines": {
                 "node": ">=6"
@@ -1134,9 +2427,9 @@
             "dev": true
         },
         "node_modules/compress-commons": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.1.tgz",
-            "integrity": "sha512-QLdDLCKNV2dtoTorqgxngQCMA+gWXkM/Nwu7FpeBhk/RdkzimqC3jueb/FDmaZeXh+uby1jkBqE3xArsLBE5wQ==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+            "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
             "dev": true,
             "dependencies": {
                 "buffer-crc32": "^0.2.13",
@@ -1191,9 +2484,9 @@
             }
         },
         "node_modules/crc32-stream": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.2.tgz",
-            "integrity": "sha512-DxFZ/Hk473b/muq1VJ///PMNLj0ZMnzye9thBpmjpJKCc5eMgB95aK8zCGrGfQ90cWo561Te6HK9D+j4KPdM6w==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+            "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
             "dev": true,
             "dependencies": {
                 "crc-32": "^1.2.0",
@@ -1245,9 +2538,9 @@
             "dev": true
         },
         "node_modules/dayjs": {
-            "version": "1.11.7",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
-            "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
+            "version": "1.11.10",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+            "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==",
             "dev": true
         },
         "node_modules/debug": {
@@ -1347,9 +2640,9 @@
             }
         },
         "node_modules/decompress-tar/node_modules/readable-stream": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "dev": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
@@ -1534,6 +2827,20 @@
                 "timers-ext": "^0.1.7"
             }
         },
+        "node_modules/define-data-property": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+            "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+            "dev": true,
+            "dependencies": {
+                "get-intrinsic": "^1.2.1",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/define-lazy-prop": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -1575,18 +2882,21 @@
             }
         },
         "node_modules/dotenv": {
-            "version": "16.0.3",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-            "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+            "version": "16.3.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+            "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
             "dev": true,
             "engines": {
                 "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/motdotla/dotenv?sponsor=1"
             }
         },
         "node_modules/dotenv-expand": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-9.0.0.tgz",
-            "integrity": "sha512-uW8Hrhp5ammm9x7kBLR6jDfujgaDarNA02tprvZdyrJ7MpdzD1KyrIHG4l+YoC2fJ2UcdFdNWNWIjt+sexBHJw==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+            "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
             "dev": true,
             "engines": {
                 "node": ">=12"
@@ -1733,6 +3043,15 @@
                 "es5-ext": "~0.10.14"
             }
         },
+        "node_modules/event-target-shim": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/events": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
@@ -1817,6 +3136,28 @@
             "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
             "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
             "dev": true
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+            "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/naturalintelligence"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "dependencies": {
+                "strnum": "^1.0.5"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
         },
         "node_modules/fastest-levenshtein": {
             "version": "1.0.16",
@@ -1904,9 +3245,9 @@
             }
         },
         "node_modules/filesize": {
-            "version": "10.0.6",
-            "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.0.6.tgz",
-            "integrity": "sha512-rzpOZ4C9vMFDqOa6dNpog92CoLYjD79dnjLk2TYDDtImRIyLTOzqojCb05Opd1WuiWjs+fshhCgTd8cl7y5t+g==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.0.tgz",
+            "integrity": "sha512-GTLKYyBSDz3nPhlLVPjPWZCnhkd9TrrRArNcy8Z+J2cqScB7h2McAzR6NBX6nYOoWafql0roY8hrocxnZBv9CQ==",
             "dev": true,
             "engines": {
                 "node": ">= 10.4.0"
@@ -2073,9 +3414,9 @@
             }
         },
         "node_modules/fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
             "dev": true,
             "hasInstallScript": true,
             "optional": true,
@@ -2087,20 +3428,24 @@
             }
         },
         "node_modules/function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-            "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+            "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
             "dev": true,
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.3"
+                "function-bind": "^1.1.2",
+                "has-proto": "^1.0.1",
+                "has-symbols": "^1.0.3",
+                "hasown": "^2.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -2220,9 +3565,9 @@
             }
         },
         "node_modules/graceful-fs": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true
         },
         "node_modules/graphlib": {
@@ -2234,18 +3579,6 @@
                 "lodash": "^4.17.15"
             }
         },
-        "node_modules/has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
-            "dependencies": {
-                "function-bind": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2253,6 +3586,30 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+            "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+            "dev": true,
+            "dependencies": {
+                "get-intrinsic": "^1.2.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+            "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/has-symbols": {
@@ -2280,6 +3637,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+            "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+            "dev": true,
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/hexoid": {
@@ -2382,9 +3751,9 @@
             "dev": true
         },
         "node_modules/inquirer": {
-            "version": "8.2.5",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz",
-            "integrity": "sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==",
+            "version": "8.2.6",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
+            "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
             "dev": true,
             "dependencies": {
                 "ansi-escapes": "^4.2.1",
@@ -2401,7 +3770,7 @@
                 "string-width": "^4.1.0",
                 "strip-ansi": "^6.0.0",
                 "through": "^2.3.6",
-                "wrap-ansi": "^7.0.0"
+                "wrap-ansi": "^6.0.1"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -2556,16 +3925,12 @@
             }
         },
         "node_modules/is-typed-array": {
-            "version": "1.1.10",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
-            "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
+            "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
             "dev": true,
             "dependencies": {
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-tostringtag": "^1.0.0"
+                "which-typed-array": "^1.1.11"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -2646,10 +4011,82 @@
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "dev": true
         },
+        "node_modules/json-colorizer": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/json-colorizer/-/json-colorizer-2.2.2.tgz",
+            "integrity": "sha512-56oZtwV1piXrQnRNTtJeqRv+B9Y/dXAYLqBBaYl/COcUdoZxgLBLAO88+CnkbT6MxNs0c5E9mPBIb2sFcNz3vw==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^2.4.1",
+                "lodash.get": "^4.4.2"
+            }
+        },
+        "node_modules/json-colorizer/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/json-colorizer/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/json-colorizer/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/json-colorizer/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true
+        },
+        "node_modules/json-colorizer/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/json-colorizer/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/json-cycle": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/json-cycle/-/json-cycle-1.3.0.tgz",
-            "integrity": "sha512-FD/SedD78LCdSvJaOUQAXseT8oQBb5z6IVYaQaCrVUlu9zOAr1BDdKyVYQaSD/GDsAMrXpKcOyBD4LIl8nfjHw==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/json-cycle/-/json-cycle-1.5.0.tgz",
+            "integrity": "sha512-GOehvd5PO2FeZ5T4c+RxobeT5a1PiGpF4u9/3+UvrMU4bhnVqzJY7hm39wg8PDCqkU91fWGH8qjWR4bn+wgq9w==",
             "dev": true,
             "engines": {
                 "node": ">= 4"
@@ -2730,9 +4167,9 @@
             }
         },
         "node_modules/jszip/node_modules/readable-stream": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "dev": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
@@ -2766,9 +4203,9 @@
             "dev": true
         },
         "node_modules/keyv": {
-            "version": "4.5.2",
-            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
-            "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
             "dev": true,
             "dependencies": {
                 "json-buffer": "3.0.1"
@@ -2787,9 +4224,9 @@
             }
         },
         "node_modules/lazystream/node_modules/readable-stream": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "dev": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
@@ -2847,6 +4284,12 @@
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
             "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+            "dev": true
+        },
+        "node_modules/lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
             "dev": true
         },
         "node_modules/lodash.isplainobject": {
@@ -2945,27 +4388,18 @@
             }
         },
         "node_modules/make-dir": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+            "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
             "dev": true,
             "dependencies": {
-                "semver": "^6.0.0"
+                "semver": "^7.5.3"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/make-dir/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
             }
         },
         "node_modules/memoizee": {
@@ -3079,13 +4513,10 @@
             }
         },
         "node_modules/minipass": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.0.tgz",
-            "integrity": "sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
             "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
             "engines": {
                 "node": ">=8"
             }
@@ -3146,19 +4577,19 @@
             "dev": true
         },
         "node_modules/ncjsm": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/ncjsm/-/ncjsm-4.3.1.tgz",
-            "integrity": "sha512-5hy/Mr7KKLS/AFyY4Be8q0aXz8wYd2PN3cSSMBeQHfcrK6Sbd0EGoQxiNrUoKMAYhl67v4A975f6Gy1oEqfJlA==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/ncjsm/-/ncjsm-4.3.2.tgz",
+            "integrity": "sha512-6d1VWA7FY31CpI4Ki97Fpm36jfURkVbpktizp8aoVViTZRQgr/0ddmlKerALSSlzfwQRBeSq1qwwVcBJK4Sk7Q==",
             "dev": true,
             "dependencies": {
                 "builtin-modules": "^3.3.0",
                 "deferred": "^0.7.11",
-                "es5-ext": "^0.10.61",
-                "es6-set": "^0.1.5",
-                "ext": "^1.6.0",
+                "es5-ext": "^0.10.62",
+                "es6-set": "^0.1.6",
+                "ext": "^1.7.0",
                 "find-requires": "^1.0.0",
                 "fs2": "^0.3.9",
-                "type": "^2.6.0"
+                "type": "^2.7.2"
             }
         },
         "node_modules/next-tick": {
@@ -3186,9 +4617,9 @@
             }
         },
         "node_modules/node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
             "dev": true,
             "dependencies": {
                 "whatwg-url": "^5.0.0"
@@ -3296,9 +4727,9 @@
             }
         },
         "node_modules/open": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-            "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+            "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
             "dev": true,
             "dependencies": {
                 "define-lazy-prop": "^2.0.0",
@@ -3642,9 +5073,9 @@
             }
         },
         "node_modules/readdir-glob": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.2.tgz",
-            "integrity": "sha512-6RLVvwJtVwEDfPdn6X6Ille4/lxGl0ATOY4FN/B9nxQcgOazvvI0nodiD19ScKq0PvA/29VpaOQML36o5IzZWA==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+            "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
             "dev": true,
             "dependencies": {
                 "minimatch": "^5.1.0"
@@ -3660,9 +5091,9 @@
             }
         },
         "node_modules/readdir-glob/node_modules/minimatch": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-            "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
             "dev": true,
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -3789,9 +5220,9 @@
             }
         },
         "node_modules/rxjs": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-            "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
             "dev": true,
             "dependencies": {
                 "tslib": "^2.1.0"
@@ -3864,64 +5295,67 @@
             }
         },
         "node_modules/serverless": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/serverless/-/serverless-3.26.0.tgz",
-            "integrity": "sha512-drVr4akkQwm2Pj7ZN9boh5PoI2nKvlXmy+Cb8Hh1Zv8ybsf47ZUQE6t7dakGA4irYf4SQCbVc72nKqISfarMCQ==",
+            "version": "3.37.0",
+            "resolved": "https://registry.npmjs.org/serverless/-/serverless-3.37.0.tgz",
+            "integrity": "sha512-HRYzduFrJTMRVknmoqdmdfZJ0c945h5jhrUf8rTzdBdCoQ2ETMFd6xlHnrAPqsEreR1apAVb0zFSZLwgO7Tigg==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
-                "@serverless/dashboard-plugin": "^6.2.2",
-                "@serverless/platform-client": "^4.3.2",
-                "@serverless/utils": "^6.8.2",
-                "ajv": "^8.11.2",
+                "@serverless/dashboard-plugin": "^7.2.0",
+                "@serverless/platform-client": "^4.5.1",
+                "@serverless/utils": "^6.13.1",
+                "abort-controller": "^3.0.0",
+                "ajv": "^8.12.0",
                 "ajv-formats": "^2.1.1",
                 "archiver": "^5.3.1",
-                "aws-sdk": "^2.1280.0",
+                "aws-sdk": "^2.1404.0",
                 "bluebird": "^3.7.2",
                 "cachedir": "^2.3.0",
                 "chalk": "^4.1.2",
                 "child-process-ext": "^2.1.1",
-                "ci-info": "^3.7.0",
+                "ci-info": "^3.8.0",
                 "cli-progress-footer": "^2.3.2",
                 "d": "^1.0.1",
-                "dayjs": "^1.11.7",
+                "dayjs": "^1.11.8",
                 "decompress": "^4.2.1",
-                "dotenv": "^16.0.3",
-                "dotenv-expand": "^9.0.0",
+                "dotenv": "^16.3.1",
+                "dotenv-expand": "^10.0.0",
                 "essentials": "^1.2.0",
                 "ext": "^1.7.0",
                 "fastest-levenshtein": "^1.0.16",
-                "filesize": "^10.0.6",
+                "filesize": "^10.0.7",
                 "fs-extra": "^10.1.0",
                 "get-stdin": "^8.0.0",
                 "globby": "^11.1.0",
-                "got": "^11.8.6",
-                "graceful-fs": "^4.2.10",
+                "graceful-fs": "^4.2.11",
                 "https-proxy-agent": "^5.0.1",
                 "is-docker": "^2.2.1",
                 "js-yaml": "^4.1.0",
-                "json-cycle": "^1.3.0",
+                "json-colorizer": "^2.2.2",
+                "json-cycle": "^1.5.0",
                 "json-refs": "^3.0.15",
                 "lodash": "^4.17.21",
                 "memoizee": "^0.4.15",
                 "micromatch": "^4.0.5",
-                "node-fetch": "^2.6.7",
+                "node-fetch": "^2.6.11",
                 "npm-registry-utilities": "^1.0.0",
                 "object-hash": "^3.0.0",
-                "open": "^8.4.0",
+                "open": "^8.4.2",
                 "path2": "^0.1.0",
                 "process-utils": "^4.0.0",
                 "promise-queue": "^2.2.5",
                 "require-from-string": "^2.0.2",
-                "semver": "^7.3.8",
+                "semver": "^7.5.3",
                 "signal-exit": "^3.0.7",
+                "stream-buffers": "^3.0.2",
                 "strip-ansi": "^6.0.1",
                 "supports-color": "^8.1.1",
-                "tar": "^6.1.13",
+                "tar": "^6.1.15",
                 "timers-ext": "^0.1.7",
                 "type": "^2.7.2",
                 "untildify": "^4.0.0",
                 "uuid": "^9.0.0",
+                "ws": "^7.5.9",
                 "yaml-ast-parser": "0.0.43"
             },
             "bin": {
@@ -3933,15 +5367,30 @@
             }
         },
         "node_modules/serverless-prune-plugin": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/serverless-prune-plugin/-/serverless-prune-plugin-2.0.1.tgz",
-            "integrity": "sha512-fWttDV5TD3K6g9NRDJUuA/cq0AzAI0ya1FZXQKtCnWFfaGP7CzZHZWzlvnNofqvKdpY8vXtaAiswc6gdHXaTUw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/serverless-prune-plugin/-/serverless-prune-plugin-2.0.2.tgz",
+            "integrity": "sha512-tW1Q8MAVmhW8KQN+e0AsSVsb9nmRWWj28xBjMwvVC3FbammmtUJT+5nRpmjxJZ6/K/j3OV1Rx8b32md71BwkYQ==",
             "dev": true,
             "dependencies": {
                 "bluebird": "^3.7.2"
             },
             "peerDependencies": {
                 "serverless": "1 || 2 || 3"
+            }
+        },
+        "node_modules/set-function-length": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
+            "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+            "dev": true,
+            "dependencies": {
+                "define-data-property": "^1.1.1",
+                "get-intrinsic": "^1.2.1",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/setimmediate": {
@@ -3992,9 +5441,9 @@
             "dev": true
         },
         "node_modules/simple-git": {
-            "version": "3.17.0",
-            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.17.0.tgz",
-            "integrity": "sha512-JozI/s8jr3nvLd9yn2jzPVHnhVzt7t7QWfcIoDcqRIGN+f1IINGv52xoZti2kkYfoRhhRvzMSNPfogHMp97rlw==",
+            "version": "3.21.0",
+            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.21.0.tgz",
+            "integrity": "sha512-oTzw9248AF5bDTMk9MrxsRzEzivMlY+DWH0yWS4VYpMhNLhDWnN06pCtaUyPnqv/FpsdeNmRqmZugMABHRPdDA==",
             "dev": true,
             "dependencies": {
                 "@kwsites/file-exists": "^1.1.1",
@@ -4061,6 +5510,15 @@
             "dev": true,
             "dependencies": {
                 "es5-ext": "^0.10.53"
+            }
+        },
+        "node_modules/stream-buffers": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.2.tgz",
+            "integrity": "sha512-DQi1h8VEBA/lURbSwFtEHnSTb9s2/pwLEaFuNhXwy1Dx3Sa0lOuYT2yNUr4/j2fs8oCAMANtrZ5OrPZtyVs3MQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.10.0"
             }
         },
         "node_modules/stream-promise": {
@@ -4130,6 +5588,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/strnum": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+            "dev": true
+        },
         "node_modules/strtok3": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
@@ -4186,14 +5650,14 @@
             }
         },
         "node_modules/tar": {
-            "version": "6.1.13",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
-            "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
+            "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
             "dev": true,
             "dependencies": {
                 "chownr": "^2.0.0",
                 "fs-minipass": "^2.0.0",
-                "minipass": "^4.0.0",
+                "minipass": "^5.0.0",
                 "minizlib": "^2.1.1",
                 "mkdirp": "^1.0.3",
                 "yallist": "^4.0.0"
@@ -4335,9 +5799,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
             "dev": true
         },
         "node_modules/type": {
@@ -4391,6 +5855,12 @@
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "dev": true
         },
         "node_modules/uni-global": {
             "version": "1.0.0",
@@ -4529,17 +5999,16 @@
             }
         },
         "node_modules/which-typed-array": {
-            "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
-            "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
+            "integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
             "dev": true,
             "dependencies": {
                 "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
+                "call-bind": "^1.0.4",
                 "for-each": "^0.3.3",
                 "gopd": "^1.0.1",
-                "has-tostringtag": "^1.0.0",
-                "is-typed-array": "^1.1.10"
+                "has-tostringtag": "^1.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -4549,9 +6018,9 @@
             }
         },
         "node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
             "dev": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
@@ -4559,10 +6028,7 @@
                 "strip-ansi": "^6.0.0"
             },
             "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+                "node": ">=8"
             }
         },
         "node_modules/wrappy": {
@@ -4682,13 +6148,34 @@
             }
         },
         "node_modules/zip-stream": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.0.tgz",
-            "integrity": "sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+            "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
             "dev": true,
             "dependencies": {
-                "archiver-utils": "^2.1.0",
-                "compress-commons": "^4.1.0",
+                "archiver-utils": "^3.0.4",
+                "compress-commons": "^4.1.2",
+                "readable-stream": "^3.6.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/zip-stream/node_modules/archiver-utils": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+            "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.2.3",
+                "graceful-fs": "^4.2.0",
+                "lazystream": "^1.0.0",
+                "lodash.defaults": "^4.2.0",
+                "lodash.difference": "^4.5.0",
+                "lodash.flatten": "^4.4.0",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.union": "^4.6.0",
+                "normalize-path": "^3.0.0",
                 "readable-stream": "^3.6.0"
             },
             "engines": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "The LDAP Password Rotation Service offers a lambda function that integrates with AWS Secrets Manager and can update the user password to a new random password and update it in AWS Secrets Manager.",
     "author": "daniel.dias@vitesco.com",
     "devDependencies": {
-        "serverless": "^3.26.0",
-        "serverless-prune-plugin": "^2.0.1"
+        "serverless": "^3.37.0",
+        "serverless-prune-plugin": "^2.0.2"
     }
 }


### PR DESCRIPTION
# Description

Upgrade the serverless version to latest to support python 3.10.

The old serverless version doesn't support python3.10 as runtime. When deploying the function, it will report the error message:
`Warning: Invalid configuration encountered
  at 'layers.ldappw.compatibleRuntimes.2': must be equal to one of the allowed values [dotnet6, dotnetcore3.1, go1.x, java11, java8, java8.al2, nodejs12.x, nodejs14.x, nodejs16.x, nodejs18.x, provided, provided.al2, python3.6, python3.7, python3.8, python3.9, ruby2.7]`

## Remark

For automation please see [closing-issues-using-keywords](
    https://help.github.com/en/articles/closing-issues-using-keywords)
