### PR TITLE
Use requirements.txt instead of pipenv requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ setup: ## Set up dependencies
 deploy: ## Deploy with serverless framework
 	@[ "${stage}" ] || ( echo ">> stage is not set call with make deploy stage=<app stage>"; exit 1 )
 	rm -rf layer/python/
-	pipenv run pip install -r <(pipenv requirements) --target layer/python
+	pipenv run pip install -r requirements.txt --target layer/python
 	pipenv run npx sls deploy --stage=${stage} --verbose
 
 .PHONY: undeploy


### PR DESCRIPTION
# Description

When deploy the service with github actions workflow, it reports the error:
`pipenv run pip install -r <(pipenv requirements) --target layer/python
ERROR: Could not open requirements file: [Errno 2] No such file or directory: '/dev/fd/63'`

To avoid stdout redirect, I update the logic to use the requirements.txt directly for pip install.
## Remark

For automation please see [closing-issues-using-keywords](
    https://help.github.com/en/articles/closing-issues-using-keywords)
