### PR TITLE
Add kms iam policies for custom keys usage

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -20,7 +20,7 @@ package:
 
 provider:
   name: aws
-  runtime: python3.9
+  runtime: python3.10
   timeout: 30
   logRetentionInDays: 14
   stage: ${opt:stage, 'dev'}
@@ -57,6 +57,14 @@ provider:
             - "secretsmanager:GetSecretValue"
             - "secretsmanager:PutSecretValue"
             - "secretsmanager:UpdateSecretVersionStage"
+        - Effect: "Allow"
+          Resource: "*"
+          Action:
+            - "kms:Encrypt"
+            - "kms:Decrypt"
+            - "kms:ReEncrypt*"
+            - "kms:GenerateDataKey*"
+            - "kms:DescribeKey"
 
 custom:
   file: ${file(./config/serverless.${self:provider.stage}.yml)}


### PR DESCRIPTION
# Description

When the secret is encrypted by custom keys, it is required for the lambda rotation function to have the kms related iam policies in order to read and rotate the secret.

The changes in this PR are mainly to grant the required kms policies to the lambda function.

## Remark

For automation please see [closing-issues-using-keywords](
    https://help.github.com/en/articles/closing-issues-using-keywords)
