### PR TITLE
chore: Exclude tests and other unused folders in the serverless config

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -9,14 +9,20 @@ package:
   individually: true
   patterns:
     - "!.venv/**"
+    - "!.github/**"
+    - "!.pytest_cache/**"
+    - "!.coverage"
+    - "!.coveragerc"
     - "!node_modules/**"
     - "!config/**"
     - "!requirements.txt"
+    - "!requirements-dev.txt"
     - "!package.json"
     - "!package-lock.json"
     - "!Makefile"
     - "!Pipfile"
     - "!Pipfile.lock"
+    - "!tests/**"
 
 provider:
   name: aws


### PR DESCRIPTION
# Description

The tests folder include the file ldap-password-rotation/tests/utilities/ldap_test/ldap-test-server-0.0.4-SNAPSHOT-jar-with-dependencies.jar. It will introduce the security issue: CVE-2018-1000134 - com.unboundid:unboundid-ldapsdk in the AWS security hub. 

This PR is to exclude the tests folder and other unused folders in the serverless config.

## Remark

For automation please see [closing-issues-using-keywords](
    https://help.github.com/en/articles/closing-issues-using-keywords)
